### PR TITLE
DNS-O-Matic is not an enterprise service.

### DIFF
--- a/update_ip_addr_dns.py
+++ b/update_ip_addr_dns.py
@@ -27,7 +27,7 @@ if __name__ == '__main__':
 
     # FIXED
     MERAKI_URL = 'https://dashboard.meraki.com/api/v0/'
-    DNS_O_URL  = 'https://' + USER_PWD + '@updates.dnsomatic.com/nic/update'
+    DNS_O_URL  = 'https://' + USER_PWD + '@updates.opendns.com/nic/update'
 
     # Grab all organizations administrated by this user
     headers = {'X-Cisco-Meraki-API-Key':API_KEY}
@@ -64,7 +64,7 @@ if __name__ == '__main__':
         r = requests.get(DNS_O_URL, data=dns_data, headers=headers)
         # Incorrect DNS-O-Matic Auth
         if r.text == 'badauth':
-            print('Incorect DNS-O-Matic Username & Password')
+            print('Incorect Umbrella Username & Password')
             exit(1)
         # Update results
         if r.text.split(' ')[0] == 'good':


### PR DESCRIPTION
Rather than update through this service, update the network directly to
OpenDNS/Umbrella. DNS-O-Matic is a consumer only service and is subject to interruptions and is not part of the Umbrella SLA. 

It is possible to update networks directly to us via our dynamic update api - updates.opendns.com. 

This update should allow it to work by updating the network directly instead of DNS-O-Matic, the API call is the same. 

I am not able to validate or verify - please validate before updating the repo. You may reach me, alexahar, on Jabber. 